### PR TITLE
Release functions and use arrays

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "go.toolsEnvVars": {
-        "GOARCH": "wasm",
-        "GOOS": "js"
-    }
-}


### PR DESCRIPTION
Previously, the js.FuncOf was never released, causing resources to be leak. That PR uses `js.FuncOf.Release()` to release all functions.

Also, the old code uses `args[0].String()`, that calls TextDecoder API, which is quite slow on most browsers, and then use `[]byte()` which may generate more allocations. That PR also replaces such function to use `arrayBuffer`.