### PR TITLE
chore: adding `//go:build js && wasm` annotation

### DIFF
--- a/fetch.go
+++ b/fetch.go
@@ -1,3 +1,5 @@
+//go:build js && wasm
+
 package fetch
 
 import (


### PR DESCRIPTION
Nowadays, without it you get `error while importing syscall/js: build constraints exclude all Go files in .../go/src/syscall/js` compiler error.